### PR TITLE
detect pe32 or pe64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,5 @@
 use anyhow::{Context, Result};
-use pelite::pe::Pe as _;
-use pelite::pe32;
-use pelite::pe32::Pe as _;
-use pelite::pe64;
 use pelite::resources::Name;
-use std::io::Cursor;
-use std::io::{Read, Seek, SeekFrom};
 mod exe;
 pub use exe::*;
 mod dll;
@@ -36,79 +30,21 @@ pub mod error {
     }
 }
 
-fn is64(bin: &[u8]) -> Result<bool> {
-    let mut file = Cursor::new(bin);
-
-    file.seek(SeekFrom::Start(0x3C))
-        .context("Failed to seek to DOS header offset (e_lfanew)")?;
-    let mut e_lfanew_bytes = [0u8; 4];
-    file.read_exact(&mut e_lfanew_bytes)
-        .context("Failed to read e_lfanew bytes")?;
-    let e_lfanew = u32::from_le_bytes(e_lfanew_bytes);
-
-    file.seek(SeekFrom::Start(e_lfanew as u64))
-        .context("Failed to seek to PE header")?;
-    let mut signature = [0u8; 4];
-    file.read_exact(&mut signature)
-        .context("Failed to read PE signature")?;
-    if &signature != b"PE\0\0" {
-        anyhow::bail!("Invalid PE signature");
-    }
-
-    file.seek(SeekFrom::Current(20))
-        .context("Failed to seek to OptionalHeader")?;
-
-    let mut magic = [0u8; 2];
-    file.read_exact(&mut magic)
-        .context("Failed to read Optional Header magic")?;
-    let magic = u16::from_le_bytes(magic);
-
-    match magic {
-        0x10b => Ok(false),
-        0x20b => Ok(true),
-        _ => anyhow::bail!("Unknown PE magic: {magic:#x}"),
-    }
-}
-
-trait PeResources {
-    fn get_resources(&'_ self) -> Option<pelite::resources::Resources<'_>>;
-}
-
-impl PeResources for pe32::PeFile<'_> {
-    fn get_resources(&'_ self) -> Option<pelite::resources::Resources<'_>> {
-        self.resources().ok()
-    }
-}
-impl PeResources for pe64::PeFile<'_> {
-    fn get_resources(&'_ self) -> Option<pelite::resources::Resources<'_>> {
-        self.resources().ok()
-    }
-}
-
 /// Generic PE file processing function that calls the appropriate handler based on file type
 fn with_pe_file<F, T>(bin: &[u8], f: F) -> Result<T>
 where
-    F: FnOnce(&dyn PeResources) -> Result<T>,
+    F: FnOnce(&pelite::PeFile<'_>) -> Result<T>,
 {
-    let is_pe64 = is64(bin)?;
-
-    if is_pe64 {
-        let pe = pe64::PeFile::from_bytes(bin).context("Failed to parse PE64 file")?;
-        f(&pe)
-    } else {
-        let pe = pe32::PeFile::from_bytes(bin).context("Failed to parse PE32 file")?;
-        f(&pe)
-    }
+    let pe = pelite::PeFile::from_bytes(bin).context("Failed to parse PE file")?;
+    f(&pe)
 }
 
 pub fn get_ico(bin: &[u8], ico_id: i32) -> Result<Vec<u8>> {
     with_pe_file(bin, |pe| extract_ico(pe, ico_id))
 }
 
-fn extract_ico<P: PeResources + ?Sized>(pe: &P, ico_id: i32) -> Result<Vec<u8>> {
-    let resources = pe
-        .get_resources()
-        .context("No resources found in PE file")?;
+fn extract_ico(pe: &pelite::PeFile, ico_id: i32) -> Result<Vec<u8>> {
+    let resources = pe.resources().context("No resources found in PE file")?;
     let group_icon_data = resources.icons().flat_map(|i| i.ok());
     for (name, res) in group_icon_data {
         if name == Name::Id(ico_id.unsigned_abs()) {
@@ -121,7 +57,7 @@ fn extract_ico<P: PeResources + ?Sized>(pe: &P, ico_id: i32) -> Result<Vec<u8>> 
 }
 
 pub fn get_icos(bin: &[u8]) -> Result<Vec<Ico>> {
-    with_pe_file(bin, |pe| extract_icos(pe))
+    with_pe_file(bin, extract_icos)
 }
 
 pub struct Ico {
@@ -129,9 +65,9 @@ pub struct Ico {
     pub data: Vec<u8>,
 }
 
-fn extract_icos<P: PeResources + ?Sized>(pe: &P) -> Result<Vec<Ico>> {
+fn extract_icos(pe: &pelite::PeFile) -> Result<Vec<Ico>> {
     let resources = pe
-        .get_resources()
+        .resources()
         .context("No resources found in PE file")?;
     let group_icon_data = resources.icons().flat_map(|i| i.ok());
     let mut v = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub mod error {
 /// Generic PE file processing function that calls the appropriate handler based on file type
 fn with_pe_file<F, T>(bin: &[u8], f: F) -> Result<T>
 where
-    F: FnOnce(&pelite::PeFile<'_>) -> Result<T>,
+    F: FnOnce(&pelite::PeFile) -> Result<T>,
 {
     let pe = pelite::PeFile::from_bytes(bin).context("Failed to parse PE file")?;
     f(&pe)
@@ -66,9 +66,7 @@ pub struct Ico {
 }
 
 fn extract_icos(pe: &pelite::PeFile) -> Result<Vec<Ico>> {
-    let resources = pe
-        .resources()
-        .context("No resources found in PE file")?;
+    let resources = pe.resources().context("No resources found in PE file")?;
     let group_icon_data = resources.icons().flat_map(|i| i.ok());
     let mut v = vec![];
     for (name, res) in group_icon_data {


### PR DESCRIPTION
I forgot which exe must use is64 to correctly determine whether it is 64-bit. I will use from_bytes here. If someone encounter problems, then submit an issue to pelite

https://github.com/CasualX/pelite/issues/285?notification_referrer_id=NT_kwDOAS9ocrQxNzU5MDE4MTg3MzoxOTg4NDE0Ng#issuecomment-3144441955